### PR TITLE
Support tokens with less-than-authorized scopes

### DIFF
--- a/test/charon_oauth2/plugs/authorization_endpoint_test.exs
+++ b/test/charon_oauth2/plugs/authorization_endpoint_test.exs
@@ -394,33 +394,7 @@ defmodule CharonOauth2.Plugs.AuthorizationEndpointTest do
                |> assert_dont_cache()
                |> redir_response(seeds.client.redirect_uris |> List.first())
 
-      assert [%{scope: ~w(write)}] = Authorizations.all()
-    end
-
-    test "existing authorization's scope is NOT reduced to request scope", seeds do
-      client = insert_test_client(scope: ~w(read write))
-
-      insert_test_authorization(
-        client_id: client.id,
-        resource_owner_id: seeds.user.id,
-        scope: ~w(read write)
-      )
-
-      assert %{"code" => _, "state" => "teststate"} =
-               conn(:post, "/", %{
-                 client_id: client.id,
-                 response_type: "code",
-                 permission_granted: true,
-                 state: "teststate",
-                 scope: "write",
-                 code_challenge: "test",
-                 code_challenge_method: "S256"
-               })
-               |> login(seeds)
-               |> AuthorizationEndpoint.call(seeds.opts)
-               |> assert_dont_cache()
-               |> redir_response(seeds.client.redirect_uris |> List.first())
-
+      # write is added, read isn't removed
       assert [%{scope: ~w(read write)}] = Authorizations.all()
     end
 


### PR DESCRIPTION
The token endpoint [supports](https://www.ietf.org/archive/id/draft-ietf-oauth-v2-1-07.html#section-3.2.2) an optional `scope` param that can be used to request a "reduced scope" token. For example, suppose the user authorized read and write, but the client needs a token that can only be used to read. We now support that parameter instead of ignoring it (although according to the spec, we can ignore it).

Additionally, the bit about only expanding scopes through the authorization endpoint now actually works.